### PR TITLE
Coupons currecies support

### DIFF
--- a/database/migrations/2024_03_05_000000_add_fixed_discount_currencies_to_coupons_table.php
+++ b/database/migrations/2024_03_05_000000_add_fixed_discount_currencies_to_coupons_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->json('fixed_discount_currencies')->nullable()->after('discount');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('coupons', function (Blueprint $table) {
+            $table->dropColumn('fixed_discount_currencies');
+        });
+    }
+};

--- a/src/Traits/HandlesCartItems.php
+++ b/src/Traits/HandlesCartItems.php
@@ -132,7 +132,7 @@ trait HandlesCartItems
 
         config('commerce.coupon.include_shipping') && $originalPrice += $shippingTotal;
 
-        $couponDiscount = $this->coupon->calculateDiscount($originalPrice);
+        $couponDiscount = $this->coupon->calculateDiscount($originalPrice, $this->currency);
 
         return $couponDiscount;
     }

--- a/src/Traits/HandlesCoupons.php
+++ b/src/Traits/HandlesCoupons.php
@@ -83,16 +83,25 @@ trait HandlesCoupons
     /**
      * Calculate the amount to discount the Order
      */
-    public function calculateDiscount($originalPrice)
+    public function calculateDiscount($originalPrice, $currency = null)
     {
+
         if (! $this->isValid()) {
             return 0;
         }
         if (! is_null($this->max_uses) && $this->times_used >= $this->max_uses) {
             return 0;
         }
+
+        
+
         if ($this->type == Coupon::TYPE_FIXED) {
-            $discount = $this->discount;
+            // TODO: Better way of handling potential enum?
+            if (!is_string($currency) && $currency?->value) {
+                $currency = $currency->value;
+            }
+            $discount = data_get($this->fixed_discount_currencies, $currency, $this->discount);
+
         } elseif ($this->type == Coupon::TYPE_PERCENTAGE) {
             $discount = ($originalPrice / 100) * $this->discount;
         }


### PR DESCRIPTION
This PR adds support for multi-currency fixed coupon discounts.

I haven't yet added tests but I see that some tests are failing for the coupons but it seems unrelated since they also fail for most recent commit.